### PR TITLE
:sparkles: Feat: 포즈등록후 디테일 페이지에서 뒤로가기 누르면 홈으로 보내기

### DIFF
--- a/src/components/header/BackButton.tsx
+++ b/src/components/header/BackButton.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router';
+import { To, useNavigate } from 'react-router';
 
 import styled from 'styled-components';
 
@@ -8,7 +8,7 @@ const Container = styled.div`
   position: absolute;
   align-items: center;
   justify-content: flex-start;
-  
+
   div {
     width: 32px;
     height: 32px;
@@ -16,7 +16,7 @@ const Container = styled.div`
     justify-content: center;
     padding: 8px 11px;
   }
-  
+
   img {
     width: 9px;
     height: 16px;
@@ -33,17 +33,14 @@ const Button = styled.button`
   cursor: pointer;
 `;
 
-export default function BackButton() {
+export default function BackButton({ location } : {location: string}) {
   const navigate = useNavigate();
 
   const isDarkMode = useReadLocalStorage('darkMode');
 
   return (
     <Container>
-      <Button onClick={() => {
-        navigate(-1);
-      }}
-      >
+      <Button onClick={() => (location.length > 0 ? navigate(location) : navigate(-1))}>
         <div>
           <img
             src={isDarkMode ? '/images/icon_back_D.svg' : '/images/icon_back_L.svg'}

--- a/src/components/header/TitleHeader.tsx
+++ b/src/components/header/TitleHeader.tsx
@@ -29,13 +29,21 @@ const Container = styled.header`
   }
 `;
 
-export default function TitleHeader({ title }: {
-  title: string
-}) {
+interface TitleHeaderProps {
+  title: string,
+  backButton? : string,
+}
+
+export default function TitleHeader({ title, backButton }: TitleHeaderProps) {
+  const backButtonLocation = backButton ?? '';
   return (
     <Container>
-      <BackButton />
+      <BackButton location={backButtonLocation} />
       <h1>{title}</h1>
     </Container>
   );
 }
+
+TitleHeader.defaultProps = {
+  backButton: '',
+};

--- a/src/components/layout/DetailLayout.tsx
+++ b/src/components/layout/DetailLayout.tsx
@@ -11,10 +11,14 @@ const Container = styled.div`
   max-height: fit-content;
 `;
 
-export default function DetailLayout() {
+export default function DetailLayout({ option }: {option:string}) {
   return (
     <Container>
-      <TitleHeader title="이 포즈로 사진을 찍어보세요!" />
+      {
+        option === 'DETAIL'
+          ? <TitleHeader title="이 포즈로 사진을 찍어보세요!" />
+          : <TitleHeader title="포즈가 등록되었어요." backButton="/main" />
+      }
       <main>
         <Outlet />
       </main>

--- a/src/components/register/AddInfo.tsx
+++ b/src/components/register/AddInfo.tsx
@@ -17,7 +17,7 @@ const QuestionTitle = styled.h2`
   font-weight: 600;
   line-height: 2.6rem;
   margin-bottom: 1.6rem;
-  
+
   span {
     margin-left: 1rem;
     font-size: 1.4rem;
@@ -41,7 +41,7 @@ const SelectBox = styled.select`
   background-position: 95% 50%;
   -webkit-appearance: none; /* 네이티브 외형 감추기 */
   -moz-appearance: none;
-  appearance: none; 
+  appearance: none;
 `;
 
 const ButtonList = styled.div`
@@ -122,7 +122,7 @@ export default function AddInfo() {
           setImgFile('');
           setFileData({ name: '' });
           // 끝나고 디테일로 보내기
-          window.location.href = `${window.location.origin}/pose/detail?poseId=${resp.data.poseId}`;
+          window.location.href = `${window.location.origin}/register/result?poseId=${resp.data.poseId}`;
         }}
       >
         등록하기

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -59,12 +59,6 @@ const routes = [
     ],
   },
   {
-    element: <DetailLayout />,
-    children: [
-      { path: '/pose/detail', element: <PoseDetailPage /> },
-    ],
-  },
-  {
     element: <MyPageLayout />,
     children: [
       { path: '/mypage', element: <MyLikePage /> },
@@ -77,6 +71,18 @@ const routes = [
     children: [
       { path: '/register', element: <RegisterPage /> },
       { path: '/register/info', element: <RegisterInfoPage /> },
+    ],
+  },
+  {
+    element: <DetailLayout option="DETAIL" />,
+    children: [
+      { path: '/pose/detail', element: <PoseDetailPage /> },
+    ],
+  },
+  {
+    element: <DetailLayout option="RESULT" />,
+    children: [
+      { path: '/register/result', element: <PoseDetailPage /> },
     ],
   },
   {


### PR DESCRIPTION
`/register`랑 `/register/info`를 페이지로 구분안하고 상태로 구분해도 어차피 결과 디테일 페이지에서는 뒤로가면 `/register`로 가더라구요ㅎ
그래서 아예 detail 페이지를 새로 만들어줘서 무조건 메인으로 보내게 했습니다
사실 원래 디자인상으로도 헤더에 타이틀이 다르긴 했어요ㅎㅎ
![image](https://github.com/pobu-team/poseplz-client/assets/52477327/82b62f02-8c5d-4290-93ef-1192423261df)
