### PR TITLE
style: UI 불편한 부분 수정

### DIFF
--- a/src/components/category/CategoryButtons.tsx
+++ b/src/components/category/CategoryButtons.tsx
@@ -38,6 +38,10 @@ const CategoryButton = styled.button<{active: boolean}>`
   font-weight: 600;
   line-height: 1.63;
   cursor: pointer;
+  max-width: 120px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis
 `;
 
 interface CategoryButtonsProps {

--- a/src/components/detail/PoseDetail.styles.tsx
+++ b/src/components/detail/PoseDetail.styles.tsx
@@ -16,12 +16,12 @@ export const PoseContainer = styled.div`
     justify-content: center;
     width: 100%;
     height: 488px;
+    padding: 60px 20px;
     background-color: ${(props) => props.theme.colors.detailButton};
     
     img {
       max-width: 300px;
       max-height: 600px;
-      padding: 24px;
       display: flex;
       width: 100%;
       height: 100%;

--- a/src/components/detail/PoseDetail.tsx
+++ b/src/components/detail/PoseDetail.tsx
@@ -37,16 +37,11 @@ const Container = styled.div`
 `;
 
 const ButtonSection = styled.section`
-  position: fixed;
-  left: 50%;
-  translate: -50%;
-  bottom: 0;
-  width: 100vw;
+  width: 100%;
   max-width: 375px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-inline: ${(props) => props.theme.sizes.contentPadding};
   @media screen and (max-width: 340px) {
     padding: 1.2rem;
   }

--- a/src/components/detail/PoseImage.tsx
+++ b/src/components/detail/PoseImage.tsx
@@ -24,7 +24,7 @@ const FullImage = styled.div`
 export const StyledAnchor = styled.a`
   position: absolute;
   right: 12px;
-  bottom: 12px;
+  bottom: 16px;
 
   display: flex;
   align-items: center;
@@ -43,8 +43,15 @@ export default function PoseImage({ poseInfo } : {poseInfo: PoseInfo}) {
   return (
     <>
       <PoseContainer>
-        <div role="button" onClick={openModal} tabIndex={0} onKeyDown={openModal}>
-          <img src={`${process.env.REACT_APP_API_BASE_URL}${poseInfo.imageUrl}`} alt={poseInfo.imageUrl} />
+        <div>
+          <img
+            role="presentation"
+            onClick={openModal}
+            onKeyDown={openModal}
+            src={`${process.env.REACT_APP_API_BASE_URL}${poseInfo.imageUrl}`}
+            alt={poseInfo.imageUrl}
+          />
+
         </div>
         <LikeButton
           likePoseIdArr={likePoseIdArr}


### PR DESCRIPTION
* 포즈 상세 페이지에서 이미지가 커서 이미지 출처 버튼이 안눌리는 경우가 있어 padding을 수정했습니다.
* 포즈 공유하기 버튼이 하단고정인 ui가 불필요한 것 같아 position:fixed 속성을 제거했습니다
* "꽁꽁 얼어붙은 한강위로 고양이가 걸어다닙니다" 와 같이 태그명이 길 경우 ui를 자연스럽게 하기 위해 말줄임 ui를 추가했습니다.
* 모달 클릭하는 영역이 너무 광범위하여 onClick 위치를 바꿨습니다.