### PR TITLE
스크롤 수정 및 불필요한 요청 방지

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom';
 import styled from 'styled-components';
 import MainHeader from '../header/MainHeader';
 import NavigationBar from '../footer/NavigationBar';
+import ScrollToTop from '../../utils/ScrollToTop';
 
 const Container = styled.div`
   width: 100%;
@@ -16,6 +17,7 @@ const Container = styled.div`
 export default function Layout() {
   return (
     <Container>
+      <ScrollToTop />
       <MainHeader />
       <main>
         <Outlet />

--- a/src/components/layout/MyPageLayout.tsx
+++ b/src/components/layout/MyPageLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import styled from 'styled-components';
 import NavigationBar from '../footer/NavigationBar';
+import ScrollToTop from '../../utils/ScrollToTop';
 
 const Container = styled.div`
   width: 100%;
@@ -14,6 +15,7 @@ const Container = styled.div`
 export default function MyPageLayout() {
   return (
     <Container>
+      <ScrollToTop />
       <main>
         <Outlet />
       </main>

--- a/src/service/AuthPoseService.ts
+++ b/src/service/AuthPoseService.ts
@@ -24,6 +24,8 @@ export default class AuthPoseService {
   async fetchMyPoses() : Promise<PoseInfo[]> {
     try {
       const token = localStorage.getItem('accessToken')?.replace(/^"|"$/g, '');
+      if (!token) return [];
+
       const { data } = await this.instance.get(`/members/me/poses?page=0&size=${MAX_IMG_COUNT}`, {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/src/utils/ScrollToTop.ts
+++ b/src/utils/ScrollToTop.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
- 로그인 안한 경우 useFetchMyPose에서 get 요청을 보내기전에 빈 배열을 리턴하도록 하였습니다.

- 홈화면/마이페이지의 경우 이동시 항상 스크롤이 맨 위로 가도록 `<ScrollToTop/>`을 적용하였습니다.
    - 이렇게 해도 navigate(-1)의 경우 과거 스크롤이 기억되기 때문에 detail에서 backbutton으로 넘어올때는 스크롤이 유지됩니다!